### PR TITLE
feat: add bulk ASIN data fetch script

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,3 +17,15 @@ npm run dev
 ```bash
 npm run build
 ```
+
+## Bulk product data fetch
+
+Create a text file `server/asins.txt` with one ASIN per line and ensure
+`KEEPA_KEY` is defined in your environment. Then run:
+
+```bash
+npm run fetch --prefix server
+```
+
+The script retrieves product data in batches of 100 ASINs and writes each
+JSON object to `server/products.jsonl`.

--- a/server/fetchAllAsins.js
+++ b/server/fetchAllAsins.js
@@ -1,0 +1,48 @@
+import fs from 'fs/promises';
+import fetch from 'node-fetch';
+import { gunzipSync } from 'zlib';
+import dotenv from 'dotenv';
+
+dotenv.config();
+
+const KEEPA_KEY = process.env.KEEPA_KEY;
+const INPUT = process.argv[2] || 'asins.txt';
+const OUTPUT = process.argv[3] || 'products.jsonl';
+const CHUNK_SIZE = 100; // Keepa allows up to 100 ASINs per request
+
+async function fetchProducts(asins) {
+  const url = `https://api.keepa.com/product?key=${KEEPA_KEY}&domain=1&asin=${asins.join(',')}&history=1&stats=90`;
+  const response = await fetch(url, { headers: { 'Accept-Encoding': 'gzip' } });
+  const buffer = Buffer.from(await response.arrayBuffer());
+  const json = JSON.parse(gunzipSync(buffer).toString());
+  return json.products || [];
+}
+
+(async () => {
+  if (!KEEPA_KEY) {
+    console.error('Missing KEEPA_KEY env var');
+    process.exit(1);
+  }
+
+  const text = await fs.readFile(INPUT, 'utf8').catch(() => null);
+  if (!text) {
+    console.error(`Input file not found: ${INPUT}`);
+    process.exit(1);
+  }
+
+  const asins = text.split(/\s+/).filter(Boolean);
+  const handle = await fs.open(OUTPUT, 'w');
+
+  for (let i = 0; i < asins.length; i += CHUNK_SIZE) {
+    const slice = asins.slice(i, i + CHUNK_SIZE);
+    console.log(`Fetching ${i + 1}-${i + slice.length} of ${asins.length}`);
+    const products = await fetchProducts(slice);
+    for (const product of products) {
+      await handle.write(`${JSON.stringify(product)}\n`);
+    }
+  }
+
+  await handle.close();
+  console.log(`Done. Wrote to ${OUTPUT}`);
+})();
+

--- a/server/package.json
+++ b/server/package.json
@@ -5,7 +5,8 @@
   "type": "module",
   "scripts": {
     "start": "node server.js",
-    "build": "echo \"Server build step not required\""
+    "build": "echo \"Server build step not required\"",
+    "fetch": "node fetchAllAsins.js"
   },
   "dependencies": {
     "dotenv": "^16.3.1",


### PR DESCRIPTION
## Summary
- add script to fetch product details for a list of ASINs via Keepa
- add npm script to run bulk fetch
- document how to fetch ASIN data in bulk

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`
- `npm run fetch --prefix server` *(fails: request to https://api.keepa.com/... failed, reason: ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_68bd5e8ec4f483269caab60c2535b11c